### PR TITLE
Fixed RTL digit directions

### DIFF
--- a/lib/src/default/digit_item.dart
+++ b/lib/src/default/digit_item.dart
@@ -82,8 +82,8 @@ class DigitItem extends BaseDigits {
     List<Widget> children = textDirection.isRtl
         ? [
             separatorWidget,
-            firstDigitWidget,
             secondDigitWidget,
+            firstDigitWidget,
           ]
         : [
             firstDigitWidget,

--- a/lib/src/separated/digit_separated_item.dart
+++ b/lib/src/separated/digit_separated_item.dart
@@ -98,10 +98,12 @@ class DigitSeparatedItem extends BaseDigitsSeparated {
       child: Row(
         mainAxisSize: MainAxisSize.min,
         mainAxisAlignment: MainAxisAlignment.center,
-        children: [
-          firstDigitWidget,
-          secondDigitWidget,
-        ],
+        children: textDirection.isRtl
+            ? [secondDigitWidget, firstDigitWidget]
+            : [
+                firstDigitWidget,
+                secondDigitWidget,
+              ],
       ),
     );
 


### PR DESCRIPTION
Before this fix, the numbers in RTL languages is being inverted, which
is not correct.

Example:

The number `21` is written in arabic as `٢١`, where `٢` is `2` and `١` is `1`.