### PR TITLE
Fix RTL digit position

### DIFF
--- a/lib/src/widgets/digit_item.dart
+++ b/lib/src/widgets/digit_item.dart
@@ -66,7 +66,9 @@ class DigitItem extends BaseDigits {
         RawDigitItem(
           duration: duration,
           timeUnit: timeUnit,
-          digitType: DigitType.first,
+          digitType: TextDirection.rtl == textDirection
+              ? DigitType.second
+              : DigitType.first,
           countUp: countUp,
           style: style,
           slideDirection: slideDirection,
@@ -75,7 +77,9 @@ class DigitItem extends BaseDigits {
         RawDigitItem(
           duration: duration,
           timeUnit: timeUnit,
-          digitType: DigitType.second,
+          digitType: TextDirection.rtl == textDirection
+              ? DigitType.first
+              : DigitType.second,
           countUp: countUp,
           style: style,
           slideDirection: slideDirection,

--- a/lib/src/widgets/digit_item.dart
+++ b/lib/src/widgets/digit_item.dart
@@ -66,9 +66,7 @@ class DigitItem extends BaseDigits {
         RawDigitItem(
           duration: duration,
           timeUnit: timeUnit,
-          digitType: TextDirection.rtl == textDirection
-              ? DigitType.second
-              : DigitType.first,
+          digitType: textDirection.isRtl ? DigitType.second : DigitType.first,
           countUp: countUp,
           style: style,
           slideDirection: slideDirection,
@@ -77,9 +75,7 @@ class DigitItem extends BaseDigits {
         RawDigitItem(
           duration: duration,
           timeUnit: timeUnit,
-          digitType: TextDirection.rtl == textDirection
-              ? DigitType.first
-              : DigitType.second,
+          digitType: textDirection.isRtl ? DigitType.first : DigitType.second,
           countUp: countUp,
           style: style,
           slideDirection: slideDirection,


### PR DESCRIPTION
This pr fixes an issue in digit_item when the text is RTL. with this fix we swap first and second digit if the text directions is RTL.
