### PR TITLE
Major refactor deprecating streamDuration in favor of using a controller.

### DIFF
--- a/example/control_duration.dart
+++ b/example/control_duration.dart
@@ -24,23 +24,19 @@ class SlideCountdownPage extends StatefulWidget {
 }
 
 class _SlideCountdownPageState extends State<SlideCountdownPage> {
-  late final StreamDuration _streamDuration;
+  late final SlideCountdownController _controller;
 
   @override
   void initState() {
     super.initState();
-    _streamDuration = StreamDuration(
-      config: const StreamDurationConfig(
-        countDownConfig: CountDownConfig(
-          duration: Duration(days: 2),
-        ),
-      ),
+    _controller = SlideCountdownController(
+      duration: const Duration(days: 2),
     );
   }
 
   @override
   void dispose() {
-    _streamDuration.dispose();
+    _controller.dispose();
     super.dispose();
   }
 
@@ -69,7 +65,7 @@ class _SlideCountdownPageState extends State<SlideCountdownPage> {
               const Text('Control Duration'),
               const SizedBox(height: 10),
               SlideCountdown(
-                streamDuration: _streamDuration,
+                controller: _controller,
                 decoration: BoxDecoration(
                   color: theme.buttonTheme.colorScheme?.primary,
                   borderRadius: BorderRadius.circular(5),
@@ -81,7 +77,7 @@ class _SlideCountdownPageState extends State<SlideCountdownPage> {
                 mainAxisAlignment: MainAxisAlignment.center,
                 children: [
                   TextButton(
-                    onPressed: () => _streamDuration.subtract(
+                    onPressed: () => _controller.subtract(
                       const Duration(seconds: 10),
                     ),
                     child: const Text('- 10 seconds'),
@@ -90,23 +86,38 @@ class _SlideCountdownPageState extends State<SlideCountdownPage> {
                     width: 10,
                   ),
                   FloatingActionButton.small(
+                    child: const Icon(Icons.stop_rounded),
+                    onPressed: () => _controller.stop(),
+                  ),
+                  FloatingActionButton.small(
                     child: const Icon(Icons.pause_rounded),
-                    onPressed: () => _streamDuration.pause(),
+                    onPressed: () => _controller.pause(),
                   ),
                   FloatingActionButton.small(
                     child: const Icon(Icons.play_arrow_rounded),
-                    onPressed: () => _streamDuration.resume(),
+                    onPressed: () => _controller.resume(),
+                  ),
+                  FloatingActionButton.small(
+                    child: const Icon(Icons.refresh_rounded),
+                    onPressed: () => _controller.reset(),
                   ),
                   const SizedBox(
                     width: 10,
                   ),
                   TextButton(
-                    onPressed: () => _streamDuration.add(
+                    onPressed: () => _controller.add(
                       const Duration(seconds: 10),
                     ),
                     child: const Text('+ 10 seconds'),
                   ),
                 ],
+              ),
+              const SizedBox(height: 20),
+              ElevatedButton(
+                onPressed: () => _controller.setDuration(
+                  const Duration(hours: 1),
+                ),
+                child: const Text('Set Duration to 1 Hour'),
               ),
             ],
           ),

--- a/example/example_raw_slide_countdown.dart
+++ b/example/example_raw_slide_countdown.dart
@@ -27,21 +27,19 @@ class ExampleRawSlideCountdown extends StatefulWidget {
 }
 
 class _ExampleRawSlideCountdownState extends State<ExampleRawSlideCountdown> {
-  late final StreamDuration streamDuration;
+  late final SlideCountdownController controller;
 
   @override
   void initState() {
-    streamDuration = StreamDuration(
-      config: const StreamDurationConfig(
-        countDownConfig: CountDownConfig(duration: defaultDuration),
-      ),
+    controller = SlideCountdownController(
+      duration: defaultDuration,
     );
     super.initState();
   }
 
   @override
   void dispose() {
-    streamDuration.dispose();
+    controller.dispose();
     super.dispose();
   }
 
@@ -56,9 +54,9 @@ class _ExampleRawSlideCountdownState extends State<ExampleRawSlideCountdown> {
           mainAxisAlignment: MainAxisAlignment.center,
           children: [
             RawSlideCountdown(
-              streamDuration: streamDuration,
+              controller: controller,
               builder: (context, duration) {
-                final countUp = streamDuration.isCountUp;
+                final countUp = controller.isCountUp;
                 return Row(
                   children: [
                     RawDigitItem(

--- a/lib/slide_countdown.dart
+++ b/lib/slide_countdown.dart
@@ -1,3 +1,4 @@
+export 'src/controller/slide_countdown_controller.dart';
 export 'src/data/config/config.dart';
 export 'src/data/stream_duration.dart';
 export 'src/models/duration_title.dart';

--- a/lib/src/controller/slide_countdown_controller.dart
+++ b/lib/src/controller/slide_countdown_controller.dart
@@ -115,6 +115,25 @@ class SlideCountdownController extends ChangeNotifier
   /// Current state of the controller.
   SlideCountdownState _state;
 
+  /// Notifier for state changes.
+  final ValueNotifier<SlideCountdownState> _stateNotifier =
+      ValueNotifier(SlideCountdownState.notStarted);
+
+  /// Returns a [ValueListenable] for the current state.
+  ///
+  /// Use this with [ValueListenableBuilder] to react to state changes:
+  /// ```dart
+  /// ValueListenableBuilder<SlideCountdownState>(
+  ///   valueListenable: controller.stateNotifier,
+  ///   builder: (context, state, child) {
+  ///     return Icon(state == SlideCountdownState.running
+  ///         ? Icons.pause
+  ///         : Icons.play_arrow);
+  ///   },
+  /// )
+  /// ```
+  ValueListenable<SlideCountdownState> get stateNotifier => _stateNotifier;
+
   /// Returns the current duration value.
   @override
   Duration get value => _value;
@@ -147,6 +166,13 @@ class SlideCountdownController extends ChangeNotifier
   /// The duration of the countdown.
   Duration get duration => _duration;
 
+  void _setState(SlideCountdownState newState) {
+    if (_state != newState) {
+      _state = newState;
+      _stateNotifier.value = newState;
+    }
+  }
+
   /// Starts the countdown timer.
   ///
   /// If the timer was previously stopped or has not been started yet,
@@ -160,7 +186,7 @@ class SlideCountdownController extends ChangeNotifier
       _onTick,
     );
     _timer?.start();
-    _state = SlideCountdownState.running;
+    _setState(SlideCountdownState.running);
     notifyListeners();
   }
 
@@ -178,7 +204,7 @@ class SlideCountdownController extends ChangeNotifier
 
   void _onDone() {
     _timer?.pause();
-    _state = SlideCountdownState.completed;
+    _setState(SlideCountdownState.completed);
     onDone?.call();
     notifyListeners();
   }
@@ -190,7 +216,7 @@ class SlideCountdownController extends ChangeNotifier
     if (_state != SlideCountdownState.running) return;
 
     _timer?.pause();
-    _state = SlideCountdownState.paused;
+    _setState(SlideCountdownState.paused);
     notifyListeners();
   }
 
@@ -209,7 +235,7 @@ class SlideCountdownController extends ChangeNotifier
 
     // State is paused
     _timer?.start();
-    _state = SlideCountdownState.running;
+    _setState(SlideCountdownState.running);
     notifyListeners();
   }
 
@@ -220,7 +246,7 @@ class SlideCountdownController extends ChangeNotifier
     _timer?.cancel();
     _timer = null;
     _reset();
-    _state = SlideCountdownState.notStarted;
+    _setState(SlideCountdownState.notStarted);
     notifyListeners();
   }
 
@@ -233,9 +259,9 @@ class SlideCountdownController extends ChangeNotifier
     _reset();
 
     if (wasRunning) {
-      _state = SlideCountdownState.running;
+      _setState(SlideCountdownState.running);
     } else if (_state == SlideCountdownState.completed) {
-      _state = SlideCountdownState.notStarted;
+      _setState(SlideCountdownState.notStarted);
     }
 
     notifyListeners();
@@ -294,6 +320,7 @@ class SlideCountdownController extends ChangeNotifier
   @override
   void dispose() {
     _timer?.cancel();
+    _stateNotifier.dispose();
     super.dispose();
   }
 }

--- a/lib/src/controller/slide_countdown_controller.dart
+++ b/lib/src/controller/slide_countdown_controller.dart
@@ -13,7 +13,21 @@ enum SlideCountdownState {
   paused,
 
   /// Timer has completed (reached zero for countdown or max for count-up).
-  completed,
+  completed;
+
+  /// A human-readable description of the current state.
+  String get description {
+    switch (this) {
+      case SlideCountdownState.notStarted:
+        return 'Not Started';
+      case SlideCountdownState.running:
+        return 'Running';
+      case SlideCountdownState.paused:
+        return 'Paused';
+      case SlideCountdownState.completed:
+        return 'Completed';
+    }
+  }
 }
 
 /// {@template slide_countdown_controller}

--- a/lib/src/controller/slide_countdown_controller.dart
+++ b/lib/src/controller/slide_countdown_controller.dart
@@ -194,12 +194,20 @@ class SlideCountdownController extends ChangeNotifier
     notifyListeners();
   }
 
-  /// Resumes the countdown timer after being paused.
+  /// Resumes the countdown timer after being paused or stopped.
   ///
-  /// Has no effect if the timer is not paused.
+  /// If the timer was stopped or has not started, this will start it.
+  /// If the timer was paused, this will resume from where it left off.
   void resume() {
-    if (_state != SlideCountdownState.paused) return;
+    if (_state == SlideCountdownState.running) return;
 
+    if (_state == SlideCountdownState.notStarted ||
+        _state == SlideCountdownState.completed) {
+      start();
+      return;
+    }
+
+    // State is paused
     _timer?.start();
     _state = SlideCountdownState.running;
     notifyListeners();

--- a/lib/src/controller/slide_countdown_controller.dart
+++ b/lib/src/controller/slide_countdown_controller.dart
@@ -135,6 +135,7 @@ class SlideCountdownController extends ChangeNotifier
 
   /// Returns a [ValueListenable] for the current state.
   ///
+  // ignore: comment_references
   /// Use this with [ValueListenableBuilder] to react to state changes:
   /// ```dart
   /// ValueListenableBuilder<SlideCountdownState>(
@@ -239,10 +240,12 @@ class SlideCountdownController extends ChangeNotifier
   /// If the timer was stopped or has not started, this will start it.
   /// If the timer was paused, this will resume from where it left off.
   void resume() {
-    if (_state == SlideCountdownState.running) return;
-
-    if (_state == SlideCountdownState.notStarted ||
+    if (_state == SlideCountdownState.running ||
         _state == SlideCountdownState.completed) {
+      return;
+    }
+
+    if (_state == SlideCountdownState.notStarted) {
       start();
       return;
     }
@@ -306,6 +309,7 @@ class SlideCountdownController extends ChangeNotifier
   }
 
   /// Sets the maximum duration for count-up mode.
+  // ignore: use_setters_to_change_properties
   void setMaxDuration(Duration? maxDuration) {
     _maxDuration = maxDuration;
   }

--- a/lib/src/controller/slide_countdown_controller.dart
+++ b/lib/src/controller/slide_countdown_controller.dart
@@ -1,0 +1,291 @@
+import 'package:flutter/foundation.dart';
+import 'package:pausable_timer/pausable_timer.dart';
+
+/// Enum representing the current state of the countdown timer.
+enum SlideCountdownState {
+  /// Timer has not been started yet.
+  notStarted,
+
+  /// Timer is currently running.
+  running,
+
+  /// Timer is paused.
+  paused,
+
+  /// Timer has completed (reached zero for countdown or max for count-up).
+  completed,
+}
+
+/// {@template slide_countdown_controller}
+/// A controller for managing the countdown timer state.
+///
+/// The controller provides methods to control the countdown timer:
+/// - [start] - Starts the countdown timer
+/// - [pause] - Pauses the countdown timer
+/// - [resume] - Resumes a paused countdown timer
+/// - [stop] - Stops the countdown timer and resets to initial duration
+/// - [reset] - Resets the countdown timer to initial duration
+/// - [setDuration] - Changes the countdown duration
+///
+/// Example usage:
+///
+/// ```dart
+/// final controller = SlideCountdownController();
+///
+/// SlideCountdown(
+///   controller: controller,
+///   duration: const Duration(minutes: 5),
+/// );
+///
+/// // Control the countdown
+/// controller.start();
+/// controller.pause();
+/// controller.resume();
+/// controller.reset();
+/// controller.stop();
+///
+/// // Change duration
+/// controller.setDuration(const Duration(minutes: 10));
+///
+/// // Don't forget to dispose
+/// controller.dispose();
+/// ```
+/// {@endtemplate}
+class SlideCountdownController extends ChangeNotifier
+    implements ValueListenable<Duration> {
+  /// {@macro slide_countdown_controller}
+  SlideCountdownController({
+    Duration? duration,
+    Duration? initialDuration,
+    bool autoPlay = true,
+    bool countUp = false,
+    Duration? maxDuration,
+    this.periodic = const Duration(seconds: 1),
+    this.onDone,
+  })  : _duration = duration ?? Duration.zero,
+        _initialDuration = initialDuration,
+        _isCountUp = countUp,
+        _maxDuration = maxDuration,
+        _value = _calculateInitialValue(
+          countUp: countUp,
+          duration: duration,
+          initialDuration: initialDuration,
+        ),
+        _state = SlideCountdownState.notStarted {
+    if (autoPlay && duration != null) {
+      start();
+    }
+  }
+
+  static Duration _calculateInitialValue({
+    required bool countUp,
+    Duration? duration,
+    Duration? initialDuration,
+  }) {
+    if (countUp) {
+      return initialDuration ?? Duration.zero;
+    }
+    return duration ?? Duration.zero;
+  }
+
+  /// The main countdown/countup duration.
+  Duration _duration;
+
+  /// Initial duration for count-up mode.
+  final Duration? _initialDuration;
+
+  /// Whether this is count up mode.
+  final bool _isCountUp;
+
+  /// Maximum duration for count-up mode.
+  Duration? _maxDuration;
+
+  /// The periodic interval for updates.
+  final Duration periodic;
+
+  /// Callback when countdown completes.
+  final VoidCallback? onDone;
+
+  /// Internal timer instance.
+  PausableTimer? _timer;
+
+  /// Current duration value.
+  Duration _value;
+
+  /// Current state of the controller.
+  SlideCountdownState _state;
+
+  /// Returns the current duration value.
+  @override
+  Duration get value => _value;
+
+  /// Whether the controller is in count-up mode.
+  bool get isCountUp => _isCountUp;
+
+  /// Returns the current state of the countdown.
+  SlideCountdownState get state => _state;
+
+  /// Returns whether the timer is currently paused.
+  bool get isPaused => _state == SlideCountdownState.paused;
+
+  /// Returns whether the timer is currently running.
+  bool get isRunning => _state == SlideCountdownState.running;
+
+  /// Returns whether the timer has completed.
+  bool get isCompleted => _state == SlideCountdownState.completed;
+
+  /// Returns whether the timer has not started.
+  bool get isNotStarted => _state == SlideCountdownState.notStarted;
+
+  /// Returns whether the countdown is finished.
+  bool get isFinished {
+    if (!_isCountUp && _value.inSeconds <= 0) return true;
+
+    return _isCountUp && _maxDuration != null && _value >= _maxDuration!;
+  }
+
+  /// The duration of the countdown.
+  Duration get duration => _duration;
+
+  /// Starts the countdown timer.
+  ///
+  /// If the timer was previously stopped or has not been started yet,
+  /// this will start it from the beginning.
+  void start() {
+    if (_state == SlideCountdownState.running) return;
+
+    _timer?.cancel();
+    _timer = PausableTimer.periodic(
+      periodic,
+      _onTick,
+    );
+    _timer?.start();
+    _state = SlideCountdownState.running;
+    notifyListeners();
+  }
+
+  void _onTick() {
+    if (_isCountUp) {
+      _value += periodic;
+    } else {
+      _value -= periodic;
+    }
+    notifyListeners();
+    if (isFinished) {
+      _onDone();
+    }
+  }
+
+  void _onDone() {
+    _timer?.pause();
+    _state = SlideCountdownState.completed;
+    onDone?.call();
+    notifyListeners();
+  }
+
+  /// Pauses the countdown timer.
+  ///
+  /// The timer can be resumed using [resume].
+  void pause() {
+    if (_state != SlideCountdownState.running) return;
+
+    _timer?.pause();
+    _state = SlideCountdownState.paused;
+    notifyListeners();
+  }
+
+  /// Resumes the countdown timer after being paused.
+  ///
+  /// Has no effect if the timer is not paused.
+  void resume() {
+    if (_state != SlideCountdownState.paused) return;
+
+    _timer?.start();
+    _state = SlideCountdownState.running;
+    notifyListeners();
+  }
+
+  /// Stops the countdown timer and resets to the initial duration.
+  ///
+  /// This is equivalent to calling [pause] followed by [reset].
+  void stop() {
+    _timer?.cancel();
+    _timer = null;
+    _reset();
+    _state = SlideCountdownState.notStarted;
+    notifyListeners();
+  }
+
+  /// Resets the countdown timer to the initial duration.
+  ///
+  /// If the timer was running, it will continue running after reset.
+  /// If the timer was paused, it will remain paused.
+  void reset() {
+    final wasRunning = _state == SlideCountdownState.running;
+    _reset();
+
+    if (wasRunning) {
+      _state = SlideCountdownState.running;
+    } else if (_state == SlideCountdownState.completed) {
+      _state = SlideCountdownState.notStarted;
+    }
+
+    notifyListeners();
+  }
+
+  void _reset() {
+    if (_isCountUp) {
+      _value = _initialDuration ?? Duration.zero;
+    } else {
+      _value = _duration;
+    }
+  }
+
+  /// Changes the countdown duration.
+  ///
+  /// This will also reset the current value to the new duration.
+  /// If [shouldReset] is true (default), the timer value will be reset to
+  /// the new duration. Otherwise, the timer will continue from its current
+  /// value.
+  void setDuration(Duration duration, {bool shouldReset = true}) {
+    _duration = duration;
+    if (shouldReset) {
+      if (!_isCountUp) {
+        _value = duration;
+      }
+      notifyListeners();
+    }
+  }
+
+  /// Sets the maximum duration for count-up mode.
+  void setMaxDuration(Duration? maxDuration) {
+    _maxDuration = maxDuration;
+  }
+
+  /// Seeks to a specific duration value.
+  ///
+  /// This directly sets the current countdown value without affecting
+  /// the timer state.
+  void seekTo(Duration duration) {
+    _value = duration;
+    notifyListeners();
+  }
+
+  /// Adds time to the current countdown.
+  void add(Duration duration) {
+    _value += duration;
+    notifyListeners();
+  }
+
+  /// Subtracts time from the current countdown.
+  void subtract(Duration duration) {
+    _value -= duration;
+    notifyListeners();
+  }
+
+  @override
+  void dispose() {
+    _timer?.cancel();
+    super.dispose();
+  }
+}

--- a/lib/src/models/slide_countdown_base.dart
+++ b/lib/src/models/slide_countdown_base.dart
@@ -27,6 +27,7 @@ abstract class SlideCountdownBase extends StatefulWidget {
     required this.countUp,
     required this.infinityCountUp,
     required this.digitsNumber,
+    @Deprecated('Deprecated in favor of controller')
     required this.streamDuration,
     required this.controller,
     required this.onChanged,
@@ -126,7 +127,7 @@ abstract class SlideCountdownBase extends StatefulWidget {
   ///
   /// Example you need use function in [StreamDuration]
   /// e.g correct, add, and subtract function
-  @Deprecated('Use controller instead')
+  @Deprecated('Deprecated in favor of controller')
   final StreamDuration? streamDuration; // ignore: deprecated_consistency
 
   /// A controller to control the countdown timer.

--- a/lib/src/models/slide_countdown_base.dart
+++ b/lib/src/models/slide_countdown_base.dart
@@ -28,6 +28,7 @@ abstract class SlideCountdownBase extends StatefulWidget {
     required this.infinityCountUp,
     required this.digitsNumber,
     required this.streamDuration,
+    required this.controller,
     required this.onChanged,
     required this.shouldShowDays,
     required this.shouldShowHours,
@@ -40,8 +41,8 @@ abstract class SlideCountdownBase extends StatefulWidget {
     required this.shouldDispose,
     super.key,
   }) : assert(
-          duration != null || streamDuration != null,
-          'Either duration or streamDuration has to be provided',
+          duration != null || streamDuration != null || controller != null,
+          'Either duration, streamDuration, or controller has to be provided',
         );
 
   /// [Duration] is the duration of the countdown slide,
@@ -125,7 +126,28 @@ abstract class SlideCountdownBase extends StatefulWidget {
   ///
   /// Example you need use function in [StreamDuration]
   /// e.g correct, add, and subtract function
-  final StreamDuration? streamDuration;
+  @Deprecated('Use controller instead')
+  final StreamDuration? streamDuration; // ignore: deprecated_consistency
+
+  /// A controller to control the countdown timer.
+  ///
+  /// Use this to start, pause, resume, stop, or reset the countdown.
+  /// When a controller is provided, [duration], [countUp], [infinityCountUp],
+  /// and [onDone] properties are ignored.
+  ///
+  /// Example:
+  /// ```dart
+  /// final controller = SlideCountdownController();
+  /// SlideCountdown(
+  ///   controller: controller,
+  ///   duration: const Duration(minutes: 5),
+  /// );
+  ///
+  /// // Control the countdown
+  /// controller.start();
+  /// controller.pause();
+  /// ```
+  final SlideCountdownController? controller;
 
   /// if you need to stream the remaining available duration,
   /// it will be called every time the duration changes.
@@ -169,7 +191,7 @@ abstract class SlideCountdownBase extends StatefulWidget {
 
   /// The position of the separator.
   final SeparatorPosition separatorPosition;
-  
+
   /// The `shouldDispose` parameter determines the behavior of the
   /// [StreamDuration] when the widget is disposed.
   /// - If set to `true` (default), the [StreamDuration] will be disposed.

--- a/lib/src/slide_countdown.dart
+++ b/lib/src/slide_countdown.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:slide_countdown/slide_countdown.dart';
 import 'package:slide_countdown/src/models/slide_countdown_base.dart';
@@ -16,6 +17,22 @@ import 'package:slide_countdown/src/widgets/digit_item.dart';
 /// SlideCountdown(
 ///   duration: const Duration(days: 2),
 /// );
+/// ```
+///
+/// With controller:
+///
+/// ```dart
+/// final controller = SlideCountdownController();
+///
+/// SlideCountdown(
+///   controller: controller,
+///   duration: const Duration(days: 2),
+/// );
+///
+/// // Control the countdown
+/// controller.start();
+/// controller.pause();
+/// controller.reset();
 /// ```
 /// {@endtemplate}
 class SlideCountdown extends SlideCountdownBase {
@@ -41,7 +58,8 @@ class SlideCountdown extends SlideCountdownBase {
     super.infinityCountUp = false,
     super.countUpAtDuration,
     super.digitsNumber,
-    super.streamDuration,
+    @Deprecated('Use controller instead') super.streamDuration,
+    super.controller,
     super.onChanged,
     super.shouldShowDays,
     super.shouldShowHours,
@@ -58,61 +76,92 @@ class SlideCountdown extends SlideCountdownBase {
 }
 
 class _SlideCountdownState extends State<SlideCountdown> {
-  late final StreamDuration _streamDuration;
+  late final ValueListenable<Duration> _durationNotifier;
+  bool _isInternalController = false;
   bool isDisposed = false;
 
   @override
   void initState() {
     super.initState();
-    _streamDurationListener();
+    _initDurationNotifier();
   }
 
   @override
   void didUpdateWidget(covariant SlideCountdown oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.streamDuration == null &&
-        widget.duration != oldWidget.duration) {
-      _streamDuration.seek(widget.duration!);
+    // ignore: deprecated_member_use_from_same_package
+    if (widget.controller == null && widget.streamDuration == null) {
+      if (widget.duration != oldWidget.duration) {
+        if (_durationNotifier is SlideCountdownController) {
+          (_durationNotifier as SlideCountdownController)
+              .setDuration(widget.duration!);
+        } else if (_durationNotifier is StreamDuration) {
+          (_durationNotifier as StreamDuration).seek(widget.duration!);
+        }
+      }
     }
   }
 
-  void _streamDurationListener() {
-    _streamDuration = widget.streamDuration ??
-        StreamDuration(
-          config: StreamDurationConfig(
-            isCountUp: widget.countUp,
-            onDone: () {
-              if (!isDisposed && mounted) {
-                widget.onDone?.call();
-              }
-            },
-            countDownConfig: CountDownConfig(
-              duration: widget.duration!,
-            ),
-            countUpConfig: CountUpConfig(
-              initialDuration:
-                  widget.countUpAtDuration != null && widget.countUpAtDuration!
-                      ? widget.duration!
-                      : Duration.zero,
-              maxDuration: widget.infinityCountUp ? null : widget.duration,
-            ),
-          ),
-        );
+  void _initDurationNotifier() {
+    // Priority: controller > streamDuration > internal controller
+    if (widget.controller != null) {
+      _durationNotifier = widget.controller!;
+      _isInternalController = false;
+      // ignore: deprecated_member_use_from_same_package
+    } else if (widget.streamDuration != null) {
+      // ignore: deprecated_member_use_from_same_package
+      _durationNotifier = widget.streamDuration!;
+      _isInternalController = false;
+    } else {
+      // Create internal controller
+      final controller = SlideCountdownController(
+        duration: widget.duration!,
+        countUp: widget.countUp,
+        maxDuration: widget.infinityCountUp ? null : widget.duration,
+        initialDuration:
+            (widget.countUpAtDuration ?? false) ? widget.duration : null,
+        onDone: () {
+          if (!isDisposed && mounted) {
+            widget.onDone?.call();
+          }
+        },
+      );
+      _durationNotifier = controller;
+      _isInternalController = true;
+    }
 
     if (widget.onChanged != null) {
-      _streamDuration.addListener(() {
-        if (!isDisposed && mounted) {
-          widget.onChanged?.call(_streamDuration.value);
-        }
-      });
+      _durationNotifier.addListener(_onDurationChanged);
     }
+  }
+
+  void _onDurationChanged() {
+    if (!isDisposed && mounted) {
+      widget.onChanged?.call(_durationNotifier.value);
+    }
+  }
+
+  bool get _isCountUp {
+    if (widget.controller != null) {
+      return widget.controller!.isCountUp;
+    }
+    // ignore: deprecated_member_use_from_same_package
+    if (widget.streamDuration != null) {
+      // ignore: deprecated_member_use_from_same_package
+      return widget.streamDuration!.isCountUp;
+    }
+    return widget.countUp;
   }
 
   @override
   void dispose() {
-    isDisposed = true; // Mark the widget as disposed.
-    if (widget.shouldDispose) {
-      _streamDuration.dispose();
+    isDisposed = true;
+    if (widget.shouldDispose && _isInternalController) {
+      if (_durationNotifier is SlideCountdownController) {
+        (_durationNotifier as SlideCountdownController).dispose();
+      } else if (_durationNotifier is StreamDuration) {
+        (_durationNotifier as StreamDuration).dispose();
+      }
     }
     super.dispose();
   }
@@ -133,159 +182,162 @@ class _SlideCountdownState extends State<SlideCountdown> {
       child: widget.suffixIcon ?? const SizedBox.shrink(),
     );
 
-    return RawSlideCountdown(
-      streamDuration: _streamDuration,
-      builder: (_, duration) {
-        if (duration.inSeconds <= 0 && widget.replacement != null) {
-          return widget.replacement!;
-        }
+    return RepaintBoundary(
+      child: ValueListenableBuilder<Duration>(
+        valueListenable: _durationNotifier,
+        builder: (context, duration, __) {
+          if (duration.inSeconds <= 0 && widget.replacement != null) {
+            return widget.replacement!;
+          }
 
-        final defaultShowDays = !(duration.inDays < 1 && !widget.showZeroValue);
-        final defaultShowHours =
-            !(duration.inHours < 1 && !widget.showZeroValue);
-        final defaultShowMinutes =
-            !(duration.inMinutes < 1 && !widget.showZeroValue);
-        final defaultShowSeconds =
-            !(duration.inSeconds < 1 && !widget.showZeroValue);
+          final defaultShowDays =
+              !(duration.inDays < 1 && !widget.showZeroValue);
+          final defaultShowHours =
+              !(duration.inHours < 1 && !widget.showZeroValue);
+          final defaultShowMinutes =
+              !(duration.inMinutes < 1 && !widget.showZeroValue);
+          final defaultShowSeconds =
+              !(duration.inSeconds < 1 && !widget.showZeroValue);
 
-        final showDays = widget.shouldShowDays != null
-            ? widget.shouldShowDays!(duration)
-            : defaultShowDays;
-        final showHours = widget.shouldShowHours != null
-            ? widget.shouldShowHours!(duration)
-            : defaultShowHours;
-        final showMinutes = widget.shouldShowMinutes != null
-            ? widget.shouldShowMinutes!(duration)
-            : defaultShowMinutes;
-        final showSeconds = widget.shouldShowSeconds != null
-            ? widget.shouldShowSeconds!(duration)
-            : defaultShowSeconds;
-        final isSeparatorTitle = widget.separatorType == SeparatorType.title;
+          final showDays = widget.shouldShowDays != null
+              ? widget.shouldShowDays!(duration)
+              : defaultShowDays;
+          final showHours = widget.shouldShowHours != null
+              ? widget.shouldShowHours!(duration)
+              : defaultShowHours;
+          final showMinutes = widget.shouldShowMinutes != null
+              ? widget.shouldShowMinutes!(duration)
+              : defaultShowMinutes;
+          final showSeconds = widget.shouldShowSeconds != null
+              ? widget.shouldShowSeconds!(duration)
+              : defaultShowSeconds;
+          final isSeparatorTitle = widget.separatorType == SeparatorType.title;
 
-        final days = DigitItem(
-          duration: duration,
-          timeUnit: TimeUnit.days,
-          padding: widget.padding,
-          decoration: widget.decoration,
-          separatorStyle: widget.separatorStyle,
-          style: widget.style,
-          slideDirection: widget.slideDirection,
-          countUp: widget.countUp,
-          separator: widget.separatorType == SeparatorType.title
-              ? durationTitle.days
-              : separator,
-          separatorPadding: widget.separatorPadding,
-          textDirection: textDirection,
-          digitsNumber: widget.digitsNumber,
-          showSeparator: (showHours || showMinutes || showSeconds) ||
-              (isSeparatorTitle && showDays),
-          slideAnimationDuration: widget.slideAnimationDuration,
-          slideAnimationCurve: widget.slideAnimationCurve,
-          separatorPosition: widget.separatorPosition,
-        );
-
-        final hours = DigitItem(
-          duration: duration,
-          timeUnit: TimeUnit.hours,
-          padding: widget.padding,
-          decoration: widget.decoration,
-          style: widget.style,
-          separatorStyle: widget.separatorStyle,
-          slideDirection: widget.slideDirection,
-          countUp: widget.countUp,
-          separator: widget.separatorType == SeparatorType.title
-              ? durationTitle.hours
-              : separator,
-          separatorPadding: widget.separatorPadding,
-          textDirection: textDirection,
-          digitsNumber: widget.digitsNumber,
-          showSeparator:
-              showMinutes || showSeconds || (isSeparatorTitle && showHours),
-          slideAnimationDuration: widget.slideAnimationDuration,
-          slideAnimationCurve: widget.slideAnimationCurve,
-          separatorPosition: widget.separatorPosition,
-        );
-
-        final minutes = DigitItem(
-          duration: duration,
-          timeUnit: TimeUnit.minutes,
-          padding: widget.padding,
-          decoration: widget.decoration,
-          style: widget.style,
-          separatorStyle: widget.separatorStyle,
-          slideDirection: widget.slideDirection,
-          countUp: widget.countUp,
-          separator: widget.separatorType == SeparatorType.title
-              ? durationTitle.minutes
-              : separator,
-          separatorPadding: widget.separatorPadding,
-          textDirection: textDirection,
-          digitsNumber: widget.digitsNumber,
-          showSeparator: showSeconds || (isSeparatorTitle && showMinutes),
-          slideAnimationDuration: widget.slideAnimationDuration,
-          slideAnimationCurve: widget.slideAnimationCurve,
-          separatorPosition: widget.separatorPosition,
-        );
-
-        final seconds = DigitItem(
-          duration: duration,
-          timeUnit: TimeUnit.seconds,
-          padding: widget.padding,
-          decoration: widget.decoration,
-          style: widget.style,
-          separatorStyle: widget.separatorStyle,
-          slideDirection: widget.slideDirection,
-          countUp: widget.countUp,
-          separator: widget.separatorType == SeparatorType.title
-              ? durationTitle.seconds
-              : separator,
-          separatorPadding: widget.separatorPadding,
-          textDirection: textDirection,
-          digitsNumber: widget.digitsNumber,
-          showSeparator: isSeparatorTitle && showSeconds,
-          slideAnimationDuration: widget.slideAnimationDuration,
-          slideAnimationCurve: widget.slideAnimationCurve,
-          separatorPosition: widget.separatorPosition,
-        );
-
-        final daysWidget = showDays ? days : const SizedBox.shrink();
-        final hoursWidget = showHours ? hours : const SizedBox.shrink();
-        final minutesWidget = showMinutes ? minutes : const SizedBox.shrink();
-        final secondsWidget = showSeconds ? seconds : const SizedBox.shrink();
-
-        final countdown = Padding(
-          padding: widget.padding,
-          child: Row(
-            mainAxisSize: MainAxisSize.min,
-            children: textDirection.isRtl
-                ? [
-                    suffixIcon,
-                    secondsWidget,
-                    minutesWidget,
-                    hoursWidget,
-                    daysWidget,
-                    leadingIcon,
-                  ]
-                : [
-                    leadingIcon,
-                    daysWidget,
-                    hoursWidget,
-                    minutesWidget,
-                    secondsWidget,
-                    suffixIcon,
-                  ],
-          ),
-        );
-
-        return Semantics(
-          label: '$duration'.replaceAll('.000000', ''),
-          container: true,
-          child: DecoratedBox(
+          final days = DigitItem(
+            duration: duration,
+            timeUnit: TimeUnit.days,
+            padding: widget.padding,
             decoration: widget.decoration,
-            child: countdown,
-          ),
-        );
-      },
+            separatorStyle: widget.separatorStyle,
+            style: widget.style,
+            slideDirection: widget.slideDirection,
+            countUp: _isCountUp,
+            separator: widget.separatorType == SeparatorType.title
+                ? durationTitle.days
+                : separator,
+            separatorPadding: widget.separatorPadding,
+            textDirection: textDirection,
+            digitsNumber: widget.digitsNumber,
+            showSeparator: (showHours || showMinutes || showSeconds) ||
+                (isSeparatorTitle && showDays),
+            slideAnimationDuration: widget.slideAnimationDuration,
+            slideAnimationCurve: widget.slideAnimationCurve,
+            separatorPosition: widget.separatorPosition,
+          );
+
+          final hours = DigitItem(
+            duration: duration,
+            timeUnit: TimeUnit.hours,
+            padding: widget.padding,
+            decoration: widget.decoration,
+            style: widget.style,
+            separatorStyle: widget.separatorStyle,
+            slideDirection: widget.slideDirection,
+            countUp: _isCountUp,
+            separator: widget.separatorType == SeparatorType.title
+                ? durationTitle.hours
+                : separator,
+            separatorPadding: widget.separatorPadding,
+            textDirection: textDirection,
+            digitsNumber: widget.digitsNumber,
+            showSeparator:
+                showMinutes || showSeconds || (isSeparatorTitle && showHours),
+            slideAnimationDuration: widget.slideAnimationDuration,
+            slideAnimationCurve: widget.slideAnimationCurve,
+            separatorPosition: widget.separatorPosition,
+          );
+
+          final minutes = DigitItem(
+            duration: duration,
+            timeUnit: TimeUnit.minutes,
+            padding: widget.padding,
+            decoration: widget.decoration,
+            style: widget.style,
+            separatorStyle: widget.separatorStyle,
+            slideDirection: widget.slideDirection,
+            countUp: _isCountUp,
+            separator: widget.separatorType == SeparatorType.title
+                ? durationTitle.minutes
+                : separator,
+            separatorPadding: widget.separatorPadding,
+            textDirection: textDirection,
+            digitsNumber: widget.digitsNumber,
+            showSeparator: showSeconds || (isSeparatorTitle && showMinutes),
+            slideAnimationDuration: widget.slideAnimationDuration,
+            slideAnimationCurve: widget.slideAnimationCurve,
+            separatorPosition: widget.separatorPosition,
+          );
+
+          final seconds = DigitItem(
+            duration: duration,
+            timeUnit: TimeUnit.seconds,
+            padding: widget.padding,
+            decoration: widget.decoration,
+            style: widget.style,
+            separatorStyle: widget.separatorStyle,
+            slideDirection: widget.slideDirection,
+            countUp: _isCountUp,
+            separator: widget.separatorType == SeparatorType.title
+                ? durationTitle.seconds
+                : separator,
+            separatorPadding: widget.separatorPadding,
+            textDirection: textDirection,
+            digitsNumber: widget.digitsNumber,
+            showSeparator: isSeparatorTitle && showSeconds,
+            slideAnimationDuration: widget.slideAnimationDuration,
+            slideAnimationCurve: widget.slideAnimationCurve,
+            separatorPosition: widget.separatorPosition,
+          );
+
+          final daysWidget = showDays ? days : const SizedBox.shrink();
+          final hoursWidget = showHours ? hours : const SizedBox.shrink();
+          final minutesWidget = showMinutes ? minutes : const SizedBox.shrink();
+          final secondsWidget = showSeconds ? seconds : const SizedBox.shrink();
+
+          final countdown = Padding(
+            padding: widget.padding,
+            child: Row(
+              mainAxisSize: MainAxisSize.min,
+              children: textDirection.isRtl
+                  ? [
+                      suffixIcon,
+                      secondsWidget,
+                      minutesWidget,
+                      hoursWidget,
+                      daysWidget,
+                      leadingIcon,
+                    ]
+                  : [
+                      leadingIcon,
+                      daysWidget,
+                      hoursWidget,
+                      minutesWidget,
+                      secondsWidget,
+                      suffixIcon,
+                    ],
+            ),
+          );
+
+          return Semantics(
+            label: '$duration'.replaceAll('.000000', ''),
+            container: true,
+            child: DecoratedBox(
+              decoration: widget.decoration,
+              child: countdown,
+            ),
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/src/slide_countdown.dart
+++ b/lib/src/slide_countdown.dart
@@ -115,7 +115,7 @@ class _SlideCountdownState extends State<SlideCountdown> {
     } else {
       // Create internal controller
       final controller = SlideCountdownController(
-        duration: widget.duration!,
+        duration: widget.duration,
         countUp: widget.countUp,
         maxDuration: widget.infinityCountUp ? null : widget.duration,
         initialDuration:

--- a/lib/src/slide_countdown_separated.dart
+++ b/lib/src/slide_countdown_separated.dart
@@ -1,6 +1,6 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:slide_countdown/slide_countdown.dart';
-
 import 'package:slide_countdown/src/models/slide_countdown_base.dart';
 import 'package:slide_countdown/src/utils/extensions.dart';
 import 'package:slide_countdown/src/utils/utils.dart';
@@ -17,6 +17,22 @@ import 'package:slide_countdown/src/widgets/digit_separated_item.dart';
 /// SlideCountdownSeparated(
 ///   duration: const Duration(days: 2),
 /// );
+/// ```
+///
+/// With controller:
+///
+/// ```dart
+/// final controller = SlideCountdownController();
+///
+/// SlideCountdownSeparated(
+///   controller: controller,
+///   duration: const Duration(days: 2),
+/// );
+///
+/// // Control the countdown
+/// controller.start();
+/// controller.pause();
+/// controller.reset();
 /// ```
 /// {@endtemplate}
 class SlideCountdownSeparated extends SlideCountdownBase {
@@ -42,7 +58,8 @@ class SlideCountdownSeparated extends SlideCountdownBase {
     super.infinityCountUp = false,
     super.countUpAtDuration,
     super.digitsNumber,
-    super.streamDuration,
+    @Deprecated('Use controller instead') super.streamDuration,
+    super.controller,
     super.onChanged,
     super.shouldShowDays,
     super.shouldShowHours,
@@ -59,53 +76,93 @@ class SlideCountdownSeparated extends SlideCountdownBase {
 }
 
 class _SlideCountdownSeparatedState extends State<SlideCountdownSeparated> {
-  late final StreamDuration _streamDuration;
+  late final ValueListenable<Duration> _durationNotifier;
+  bool _isInternalController = false;
+  bool isDisposed = false;
 
   @override
   void initState() {
     super.initState();
-    _streamDurationListener();
+    _initDurationNotifier();
   }
 
   @override
   void didUpdateWidget(covariant SlideCountdownSeparated oldWidget) {
     super.didUpdateWidget(oldWidget);
-    if (widget.streamDuration == null) {
+    // ignore: deprecated_member_use_from_same_package
+    if (widget.controller == null && widget.streamDuration == null) {
       if (widget.duration != oldWidget.duration) {
-        _streamDuration.seek(widget.duration!);
+        if (_durationNotifier is SlideCountdownController) {
+          (_durationNotifier as SlideCountdownController)
+              .setDuration(widget.duration!);
+        } else if (_durationNotifier is StreamDuration) {
+          (_durationNotifier as StreamDuration).seek(widget.duration!);
+        }
       }
     }
   }
 
-  void _streamDurationListener() {
-    _streamDuration = widget.streamDuration ??
-        StreamDuration(
-          config: StreamDurationConfig(
-            isCountUp: widget.countUp,
-            onDone: widget.onDone,
-            countDownConfig: CountDownConfig(
-              duration: widget.duration!,
-            ),
-            countUpConfig: CountUpConfig(
-              initialDuration:
-                  widget.countUpAtDuration != null && widget.countUpAtDuration!
-                      ? widget.duration!
-                      : Duration.zero,
-              maxDuration: widget.infinityCountUp ? null : widget.duration,
-            ),
-          ),
-        );
+  void _initDurationNotifier() {
+    // Priority: controller > streamDuration > internal controller
+    if (widget.controller != null) {
+      _durationNotifier = widget.controller!;
+      _isInternalController = false;
+      // ignore: deprecated_member_use_from_same_package
+    } else if (widget.streamDuration != null) {
+      // ignore: deprecated_member_use_from_same_package
+      _durationNotifier = widget.streamDuration!;
+      _isInternalController = false;
+    } else {
+      // Create internal controller
+      final controller = SlideCountdownController(
+        duration: widget.duration!,
+        countUp: widget.countUp,
+        maxDuration: widget.infinityCountUp ? null : widget.duration,
+        initialDuration:
+            (widget.countUpAtDuration ?? false) ? widget.duration : null,
+        onDone: () {
+          if (!isDisposed && mounted) {
+            widget.onDone?.call();
+          }
+        },
+      );
+      _durationNotifier = controller;
+      _isInternalController = true;
+    }
 
     if (widget.onChanged != null) {
-      _streamDuration.addListener(() {
-        widget.onChanged?.call(_streamDuration.value);
-      });
+      _durationNotifier.addListener(_onDurationChanged);
     }
+  }
+
+  void _onDurationChanged() {
+    if (!isDisposed && mounted) {
+      widget.onChanged?.call(_durationNotifier.value);
+    }
+  }
+
+  bool get _isCountUp {
+    if (widget.controller != null) {
+      return widget.controller!.isCountUp;
+    }
+    // ignore: deprecated_member_use_from_same_package
+    if (widget.streamDuration != null) {
+      // ignore: deprecated_member_use_from_same_package
+      return widget.streamDuration!.isCountUp;
+    }
+    return widget.countUp;
   }
 
   @override
   void dispose() {
-    if (widget.shouldDispose) _streamDuration.dispose();
+    isDisposed = true;
+    if (widget.shouldDispose && _isInternalController) {
+      if (_durationNotifier is SlideCountdownController) {
+        (_durationNotifier as SlideCountdownController).dispose();
+      } else if (_durationNotifier is StreamDuration) {
+        (_durationNotifier as StreamDuration).dispose();
+      }
+    }
     super.dispose();
   }
 
@@ -125,151 +182,154 @@ class _SlideCountdownSeparatedState extends State<SlideCountdownSeparated> {
       child: widget.suffixIcon ?? const SizedBox.shrink(),
     );
 
-    return RawSlideCountdown(
-      streamDuration: _streamDuration,
-      builder: (_, duration) {
-        if (duration.inSeconds <= 0 && widget.replacement != null) {
-          return widget.replacement!;
-        }
+    return RepaintBoundary(
+      child: ValueListenableBuilder<Duration>(
+        valueListenable: _durationNotifier,
+        builder: (context, duration, __) {
+          if (duration.inSeconds <= 0 && widget.replacement != null) {
+            return widget.replacement!;
+          }
 
-        final defaultShowDays = !(duration.inDays < 1 && !widget.showZeroValue);
-        final defaultShowHours =
-            !(duration.inHours < 1 && !widget.showZeroValue);
-        final defaultShowMinutes =
-            !(duration.inMinutes < 1 && !widget.showZeroValue);
-        final defaultShowSeconds =
-            !(duration.inSeconds < 1 && !widget.showZeroValue);
+          final defaultShowDays =
+              !(duration.inDays < 1 && !widget.showZeroValue);
+          final defaultShowHours =
+              !(duration.inHours < 1 && !widget.showZeroValue);
+          final defaultShowMinutes =
+              !(duration.inMinutes < 1 && !widget.showZeroValue);
+          final defaultShowSeconds =
+              !(duration.inSeconds < 1 && !widget.showZeroValue);
 
-        final showDays = widget.shouldShowDays != null
-            ? widget.shouldShowDays!(duration)
-            : defaultShowDays;
-        final showHours = widget.shouldShowHours != null
-            ? widget.shouldShowHours!(duration)
-            : defaultShowHours;
-        final showMinutes = widget.shouldShowMinutes != null
-            ? widget.shouldShowMinutes!(duration)
-            : defaultShowMinutes;
-        final showSeconds = widget.shouldShowSeconds != null
-            ? widget.shouldShowSeconds!(duration)
-            : defaultShowSeconds;
+          final showDays = widget.shouldShowDays != null
+              ? widget.shouldShowDays!(duration)
+              : defaultShowDays;
+          final showHours = widget.shouldShowHours != null
+              ? widget.shouldShowHours!(duration)
+              : defaultShowHours;
+          final showMinutes = widget.shouldShowMinutes != null
+              ? widget.shouldShowMinutes!(duration)
+              : defaultShowMinutes;
+          final showSeconds = widget.shouldShowSeconds != null
+              ? widget.shouldShowSeconds!(duration)
+              : defaultShowSeconds;
 
-        final isSeparatorTitle = widget.separatorType == SeparatorType.title;
+          final isSeparatorTitle = widget.separatorType == SeparatorType.title;
 
-        final days = DigitSeparatedItem(
-          duration: duration,
-          timeUnit: TimeUnit.days,
-          padding: widget.padding,
-          decoration: widget.decoration,
-          style: widget.style,
-          separatorStyle: widget.separatorStyle,
-          slideDirection: widget.slideDirection,
-          countUp: widget.countUp,
-          separatorPadding: widget.separatorPadding,
-          separator: widget.separatorType == SeparatorType.title
-              ? durationTitle.days
-              : separator,
-          textDirection: textDirection,
-          digitsNumber: widget.digitsNumber,
-          showSeparator: (showHours || showMinutes || showSeconds) ||
-              (isSeparatorTitle && showDays),
-          slideAnimationDuration: widget.slideAnimationDuration,
-          slideAnimationCurve: widget.slideAnimationCurve,
-          separatorPosition: widget.separatorPosition,
-        );
+          final days = DigitSeparatedItem(
+            duration: duration,
+            timeUnit: TimeUnit.days,
+            padding: widget.padding,
+            decoration: widget.decoration,
+            style: widget.style,
+            separatorStyle: widget.separatorStyle,
+            slideDirection: widget.slideDirection,
+            countUp: _isCountUp,
+            separatorPadding: widget.separatorPadding,
+            separator: widget.separatorType == SeparatorType.title
+                ? durationTitle.days
+                : separator,
+            textDirection: textDirection,
+            digitsNumber: widget.digitsNumber,
+            showSeparator: (showHours || showMinutes || showSeconds) ||
+                (isSeparatorTitle && showDays),
+            slideAnimationDuration: widget.slideAnimationDuration,
+            slideAnimationCurve: widget.slideAnimationCurve,
+            separatorPosition: widget.separatorPosition,
+          );
 
-        final hours = DigitSeparatedItem(
-          duration: duration,
-          timeUnit: TimeUnit.hours,
-          padding: widget.padding,
-          decoration: widget.decoration,
-          style: widget.style,
-          separatorStyle: widget.separatorStyle,
-          slideDirection: widget.slideDirection,
-          countUp: widget.countUp,
-          separatorPadding: widget.separatorPadding,
-          separator: widget.separatorType == SeparatorType.title
-              ? durationTitle.hours
-              : separator,
-          textDirection: textDirection,
-          digitsNumber: widget.digitsNumber,
-          showSeparator:
-              showMinutes || showSeconds || (isSeparatorTitle && showHours),
-          slideAnimationDuration: widget.slideAnimationDuration,
-          slideAnimationCurve: widget.slideAnimationCurve,
-          separatorPosition: widget.separatorPosition,
-        );
+          final hours = DigitSeparatedItem(
+            duration: duration,
+            timeUnit: TimeUnit.hours,
+            padding: widget.padding,
+            decoration: widget.decoration,
+            style: widget.style,
+            separatorStyle: widget.separatorStyle,
+            slideDirection: widget.slideDirection,
+            countUp: _isCountUp,
+            separatorPadding: widget.separatorPadding,
+            separator: widget.separatorType == SeparatorType.title
+                ? durationTitle.hours
+                : separator,
+            textDirection: textDirection,
+            digitsNumber: widget.digitsNumber,
+            showSeparator:
+                showMinutes || showSeconds || (isSeparatorTitle && showHours),
+            slideAnimationDuration: widget.slideAnimationDuration,
+            slideAnimationCurve: widget.slideAnimationCurve,
+            separatorPosition: widget.separatorPosition,
+          );
 
-        final minutes = DigitSeparatedItem(
-          duration: duration,
-          timeUnit: TimeUnit.minutes,
-          padding: widget.padding,
-          decoration: widget.decoration,
-          style: widget.style,
-          separatorStyle: widget.separatorStyle,
-          slideDirection: widget.slideDirection,
-          countUp: widget.countUp,
-          separatorPadding: widget.separatorPadding,
-          separator: widget.separatorType == SeparatorType.title
-              ? durationTitle.minutes
-              : separator,
-          textDirection: textDirection,
-          digitsNumber: widget.digitsNumber,
-          showSeparator: showSeconds || (isSeparatorTitle && showMinutes),
-          slideAnimationDuration: widget.slideAnimationDuration,
-          slideAnimationCurve: widget.slideAnimationCurve,
-          separatorPosition: widget.separatorPosition,
-        );
+          final minutes = DigitSeparatedItem(
+            duration: duration,
+            timeUnit: TimeUnit.minutes,
+            padding: widget.padding,
+            decoration: widget.decoration,
+            style: widget.style,
+            separatorStyle: widget.separatorStyle,
+            slideDirection: widget.slideDirection,
+            countUp: _isCountUp,
+            separatorPadding: widget.separatorPadding,
+            separator: widget.separatorType == SeparatorType.title
+                ? durationTitle.minutes
+                : separator,
+            textDirection: textDirection,
+            digitsNumber: widget.digitsNumber,
+            showSeparator: showSeconds || (isSeparatorTitle && showMinutes),
+            slideAnimationDuration: widget.slideAnimationDuration,
+            slideAnimationCurve: widget.slideAnimationCurve,
+            separatorPosition: widget.separatorPosition,
+          );
 
-        final seconds = DigitSeparatedItem(
-          duration: duration,
-          timeUnit: TimeUnit.seconds,
-          padding: widget.padding,
-          decoration: widget.decoration,
-          style: widget.style,
-          separatorStyle: widget.separatorStyle,
-          slideDirection: widget.slideDirection,
-          countUp: widget.countUp,
-          separatorPadding: widget.separatorPadding,
-          separator: widget.separatorType == SeparatorType.title
-              ? durationTitle.seconds
-              : separator,
-          textDirection: textDirection,
-          digitsNumber: widget.digitsNumber,
-          showSeparator: isSeparatorTitle && showSeconds,
-          slideAnimationDuration: widget.slideAnimationDuration,
-          slideAnimationCurve: widget.slideAnimationCurve,
-          separatorPosition: widget.separatorPosition,
-        );
+          final seconds = DigitSeparatedItem(
+            duration: duration,
+            timeUnit: TimeUnit.seconds,
+            padding: widget.padding,
+            decoration: widget.decoration,
+            style: widget.style,
+            separatorStyle: widget.separatorStyle,
+            slideDirection: widget.slideDirection,
+            countUp: _isCountUp,
+            separatorPadding: widget.separatorPadding,
+            separator: widget.separatorType == SeparatorType.title
+                ? durationTitle.seconds
+                : separator,
+            textDirection: textDirection,
+            digitsNumber: widget.digitsNumber,
+            showSeparator: isSeparatorTitle && showSeconds,
+            slideAnimationDuration: widget.slideAnimationDuration,
+            slideAnimationCurve: widget.slideAnimationCurve,
+            separatorPosition: widget.separatorPosition,
+          );
 
-        final daysWidget = showDays ? days : const SizedBox.shrink();
+          final daysWidget = showDays ? days : const SizedBox.shrink();
 
-        final hoursWidget = showHours ? hours : const SizedBox.shrink();
+          final hoursWidget = showHours ? hours : const SizedBox.shrink();
 
-        final minutesWidget = showMinutes ? minutes : const SizedBox.shrink();
+          final minutesWidget = showMinutes ? minutes : const SizedBox.shrink();
 
-        final secondsWidget = showSeconds ? seconds : const SizedBox.shrink();
+          final secondsWidget = showSeconds ? seconds : const SizedBox.shrink();
 
-        return Row(
-          mainAxisSize: MainAxisSize.min,
-          children: textDirection.isRtl
-              ? [
-                  suffixIcon,
-                  secondsWidget,
-                  minutesWidget,
-                  hoursWidget,
-                  daysWidget,
-                  leadingIcon,
-                ]
-              : [
-                  leadingIcon,
-                  daysWidget,
-                  hoursWidget,
-                  minutesWidget,
-                  secondsWidget,
-                  suffixIcon,
-                ],
-        );
-      },
+          return Row(
+            mainAxisSize: MainAxisSize.min,
+            children: textDirection.isRtl
+                ? [
+                    suffixIcon,
+                    secondsWidget,
+                    minutesWidget,
+                    hoursWidget,
+                    daysWidget,
+                    leadingIcon,
+                  ]
+                : [
+                    leadingIcon,
+                    daysWidget,
+                    hoursWidget,
+                    minutesWidget,
+                    secondsWidget,
+                    suffixIcon,
+                  ],
+          );
+        },
+      ),
     );
   }
 }

--- a/lib/src/slide_countdown_separated.dart
+++ b/lib/src/slide_countdown_separated.dart
@@ -115,7 +115,7 @@ class _SlideCountdownSeparatedState extends State<SlideCountdownSeparated> {
     } else {
       // Create internal controller
       final controller = SlideCountdownController(
-        duration: widget.duration!,
+        duration: widget.duration,
         countUp: widget.countUp,
         maxDuration: widget.infinityCountUp ? null : widget.duration,
         initialDuration:

--- a/lib/src/widgets/raw_digit_item.dart
+++ b/lib/src/widgets/raw_digit_item.dart
@@ -104,10 +104,36 @@ class _RawDigitItemState extends State<RawDigitItem>
     setState(() {});
   }
 
-  int get maxDigit =>
-      widget.digitType == DigitType.first && widget.timeUnit != TimeUnit.days
-          ? 5
-          : 9;
+  int get maxDigit {
+    // For the first digit (tens place)
+    if (widget.digitType == DigitType.first) {
+      switch (widget.timeUnit) {
+        case TimeUnit.days:
+          return 9;
+        case TimeUnit.hours:
+          return 2; // Hours go 00-23, so first digit max is 2
+        case TimeUnit.minutes:
+        case TimeUnit.seconds:
+          return 5; // Minutes/seconds go 00-59, so first digit max is 5
+      }
+    }
+    // For the second digit (units place)
+    if (widget.timeUnit == TimeUnit.hours) {
+      // Hours second digit max depends on the first digit:
+      // - If first digit is 2 (20-23), second digit max is 3
+      // - If first digit is 0 or 1 (00-19), second digit max is 9
+      final hoursFirstDigit = duration.hoursFirstDigit;
+      // When counting down and at 0X hours, next will be 2X, so max is 3
+      // When counting up and at 2X hours, next will be 0X, so max is 3
+      if (widget.countUp) {
+        return hoursFirstDigit == 2 ? 3 : 9;
+      } else {
+        // Counting down: if first digit is 0, we'll roll to 23, so max is 3
+        return hoursFirstDigit == 0 ? 3 : 9;
+      }
+    }
+    return 9;
+  }
 
   int minMax(int value) {
     if (widget.countUp) {

--- a/lib/src/widgets/raw_slide_countdown.dart
+++ b/lib/src/widgets/raw_slide_countdown.dart
@@ -1,3 +1,4 @@
+import 'package:flutter/foundation.dart';
 import 'package:flutter/material.dart';
 import 'package:slide_countdown/slide_countdown.dart';
 
@@ -20,50 +21,60 @@ typedef RawSlideCountdownBuilder = Widget Function(
 );
 
 /// {@template raw_slide_countdown}
-/// A widget that displays a countdown based on a [StreamDuration].
+/// A widget that displays a countdown based on a [SlideCountdownController]
+/// or [StreamDuration].
 ///
-/// The [RawSlideCountdown] widget listens to the streamDuration.durationLeft
-/// stream and updates its display based on the received duration values.
+/// The [RawSlideCountdown] widget listens to the controller or streamDuration
+/// and updates its display based on the received duration values.
 ///
 /// The [builder] function is used to build the widget based on the current
 /// [BuildContext] and the remaining [Duration] received from the stream.
 ///
-/// Example:
+/// Example with controller:
 ///
 /// ```dart
+/// final controller = SlideCountdownController(
+///   duration: const Duration(minutes: 5),
+/// );
+///
 /// RawSlideCountdown(
-///   streamDuration: myStreamDuration,
+///   controller: controller,
 ///   builder: (BuildContext context, Duration remainingDuration) {
 ///     return RawDigitItem(
 ///         duration: remainingDuration,
 ///         timeUnit: TimeUnit.seconds,
 ///         digitType: DigitType.second,
-///         countUp: myStreamDuration.isCountUp,
+///         countUp: controller.isCountUp,
 ///     );
 ///   },
 /// )
 /// ```
 ///
-/// In the above example, the `RawSlideCountdown` widget listens to the
-/// `myStreamDuration.durationLeft` stream and updates the displayed text
-/// based on the remaining duration.
-///
 /// See also:
 ///
-/// - [StreamDuration], which represents a stream of countdown durations.
+/// - [SlideCountdownController], which provides the countdown duration and
+///   control methods.
 /// - [RawSlideCountdownBuilder], a function signature for the builder used
 ///   to create the countdown widget.
 /// {@endtemplate}
 class RawSlideCountdown extends StatelessWidget {
   /// {@macro raw_slide_countdown}
   const RawSlideCountdown({
-    required this.streamDuration,
     required this.builder,
+    this.controller,
+    @Deprecated('Use controller instead') this.streamDuration,
     super.key,
-  });
+  }) : assert(
+          controller != null || streamDuration != null,
+          'Either controller or streamDuration must be provided',
+        );
+
+  /// The [SlideCountdownController] that provides the countdown duration.
+  final SlideCountdownController? controller;
 
   /// The [StreamDuration] that provides the countdown duration.
-  final StreamDuration streamDuration;
+  @Deprecated('Use controller instead')
+  final StreamDuration? streamDuration;
 
   /// The builder function used to create the countdown widget.
   /// {@macro raw_slide_countdown_builder}
@@ -71,9 +82,14 @@ class RawSlideCountdown extends StatelessWidget {
 
   @override
   Widget build(BuildContext context) {
+    // ignore: deprecated_member_use_from_same_package, omit_local_variable_types
+    final ValueListenable<Duration> listenable =
+        // ignore: deprecated_member_use_from_same_package
+        (controller as ValueListenable<Duration>?) ?? streamDuration!;
+
     return RepaintBoundary(
-      child: ValueListenableBuilder(
-        valueListenable: streamDuration,
+      child: ValueListenableBuilder<Duration>(
+        valueListenable: listenable,
         builder: (_, duration, __) => builder(context, duration),
       ),
     );


### PR DESCRIPTION
This pull request introduces a new controller-based API for managing countdown timers, deprecates the old `StreamDuration`-based approach, and updates both the core library and example usages to reflect these changes. The new `SlideCountdownController` offers a more flexible and intuitive way to control countdown behavior, including starting, pausing, resuming, stopping, resetting, and changing durations. Existing widgets and APIs are updated for backward compatibility and to support the new controller.

**Core Library Enhancements**

* Added `SlideCountdownController` with comprehensive timer control methods and state management, including support for start, pause, resume, stop, reset, add, subtract, and set duration operations. (`lib/src/controller/slide_countdown_controller.dart`)
* Updated `SlideCountdown` and `RawSlideCountdown` widgets to accept a `controller` parameter, deprecating the old `streamDuration` parameter. The widget now prioritizes `controller` over `streamDuration`, and falls back to an internal controller if neither is provided. (`lib/src/models/slide_countdown_base.dart`, `lib/src/slide_countdown.dart`) [[1]](diffhunk://#diff-ff1923df5e599431c129a8f87e3f483426cffa9fc91ed8c4a8f3b96cb2f885caR30-R32) [[2]](diffhunk://#diff-ff1923df5e599431c129a8f87e3f483426cffa9fc91ed8c4a8f3b96cb2f885caL43-R46) [[3]](diffhunk://#diff-ff1923df5e599431c129a8f87e3f483426cffa9fc91ed8c4a8f3b96cb2f885caL128-R151) [[4]](diffhunk://#diff-11d39ddf1098b4f70f91d826c39f96f77080cf1766d68014a9e81ebb56bc0e89L44-R62) [[5]](diffhunk://#diff-11d39ddf1098b4f70f91d826c39f96f77080cf1766d68014a9e81ebb56bc0e89L61-R164)
* Exported the new controller from the main library file for public use. (`lib/slide_countdown.dart`)

**Fix Visual Glitch**
* Fixed an issue where starting the timer with a 2 days `Duration` would result in the following timer to be displayed: `01:59:59:59`.

**Example and Usage Updates**

* Refactored example files to use `SlideCountdownController` instead of `StreamDuration`, updating all control logic and widget parameters accordingly. (`example/control_duration.dart`, `example/example_raw_slide_countdown.dart`) [[1]](diffhunk://#diff-6eba9735a2823cd61f0bba390fa8a63869f96f39bbe4736d14ac9ee0e346ff0fL27-R39) [[2]](diffhunk://#diff-6eba9735a2823cd61f0bba390fa8a63869f96f39bbe4736d14ac9ee0e346ff0fL72-R68) [[3]](diffhunk://#diff-6eba9735a2823cd61f0bba390fa8a63869f96f39bbe4736d14ac9ee0e346ff0fL84-R121) [[4]](diffhunk://#diff-2258ce9bd7289354c7e68c1efb1176f4196359d25d0f6b7cc9bfb76c24a30916L30-R42) [[5]](diffhunk://#diff-2258ce9bd7289354c7e68c1efb1176f4196359d25d0f6b7cc9bfb76c24a30916L59-R59)
* Added new UI controls in the example to demonstrate controller capabilities, such as stop, reset, and set duration buttons. (`example/control_duration.dart`)

**Documentation and Backward Compatibility**

* Updated widget documentation and constructor assertions to reflect the new controller-based API and clarify backward compatibility with deprecated `streamDuration`. (`lib/src/models/slide_countdown_base.dart`, `lib/src/slide_countdown.dart`) [[1]](diffhunk://#diff-ff1923df5e599431c129a8f87e3f483426cffa9fc91ed8c4a8f3b96cb2f885caR30-R32) [[2]](diffhunk://#diff-ff1923df5e599431c129a8f87e3f483426cffa9fc91ed8c4a8f3b96cb2f885caL43-R46) [[3]](diffhunk://#diff-ff1923df5e599431c129a8f87e3f483426cffa9fc91ed8c4a8f3b96cb2f885caL128-R151) [[4]](diffhunk://#diff-11d39ddf1098b4f70f91d826c39f96f77080cf1766d68014a9e81ebb56bc0e89R21-R36)

These changes modernize the countdown timer API, improve usability, and ensure a smooth migration path for existing users.